### PR TITLE
Make static pid a dynamic call based on name

### DIFF
--- a/tools/general_process_profiler.py
+++ b/tools/general_process_profiler.py
@@ -48,7 +48,6 @@ def general_process_profiler():
     filename = input(f"\n{BRIGHT_CYAN}Enter the name of the configuration file:{RESET}\n")
     sanitized_filename = filename.replace(".", "-")
     process_name = input(f"\n{BRIGHT_CYAN}Enter the process name to monitor:{RESET}\n")
-    process_id = int(find_pid_by_name(process_name))
     interval = input(f"\n{BRIGHT_CYAN}Enter the monitoring interval in seconds:{RESET}\n")
     # General Process Profiler Template
     template = f"""


### PR DESCRIPTION
Before we had the PID as a static hard coded entry which if the application died or changed PID would error on the next try because of the PID change. Now we are calling for the PID via the process name each time to always have the right PID.